### PR TITLE
Log AI request errors to declaration chatter

### DIFF
--- a/planetio_ai/wizard/summarize_documents_wizard.py
+++ b/planetio_ai/wizard/summarize_documents_wizard.py
@@ -59,6 +59,10 @@ class PlanetioSummarizeWizard(models.Model):
             )
 
             req.run_now()
+            if getattr(req, "status", None) == "error":
+                rec.message_post(body=f"AI request error: {req.error_message}")
+                continue
+
             summary = req.response_text or ""
             if not summary:
                 continue

--- a/tests/test_ai_chatter.py
+++ b/tests/test_ai_chatter.py
@@ -1,0 +1,61 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+# Ensure repo root on path
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+# Stub minimal odoo package for import
+odoo = types.ModuleType('odoo')
+odoo.api = types.SimpleNamespace()
+odoo.fields = types.SimpleNamespace()
+odoo.models = types.SimpleNamespace(Model=object, AbstractModel=object)
+sys.modules.setdefault('odoo', odoo)
+
+module_path = repo_root / 'planetio_ai' / 'wizard' / 'summarize_documents_wizard.py'
+spec = importlib.util.spec_from_file_location('summ_wizard', module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+class DummyAttachments:
+    def __init__(self, ids):
+        self.ids = ids
+
+class FakeAiRequest:
+    def __init__(self):
+        self.status = 'error'
+        self.error_message = 'boom'
+        self.response_text = ''
+    def run_now(self):
+        pass
+
+class FakeAiRequestModel:
+    def create(self, vals):
+        return FakeAiRequest()
+
+class FakeEnv(dict):
+    pass
+
+class FakeAttachmentModel:
+    def create(self, vals):
+        return vals
+
+class FakeDeclaration(mod.PlanetioSummarizeWizard):
+    def __init__(self):
+        self.env = FakeEnv({'ai.request': FakeAiRequestModel(), 'ir.attachment': FakeAttachmentModel()})
+        self.attachment_ids = DummyAttachments([1])
+        self._name = 'eudr.declaration'
+        self.id = 1
+        self.messages = []
+    def __iter__(self):
+        yield self
+    def message_post(self, body=None, subtype_xmlid=None):
+        self.messages.append(body)
+
+
+def test_error_message_posted():
+    rec = FakeDeclaration()
+    rec.action_ai_analyze()
+    assert any('boom' in m for m in rec.messages)


### PR DESCRIPTION
## Summary
- Log AI request errors on declarations when running the AI summarizer
- Add tests to ensure AI errors are posted to chatter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4b2c53c0c8333a703906fedac60c9

## Summary by Sourcery

Log AI request errors to declaration chatter and add tests to ensure errors are posted

Enhancements:
- Log AI request errors to chatter on declarations when AI summarizer fails

Tests:
- Add test to verify AI error messages are posted to chatter