### PR TITLE
Add debug toggle to streamline Excel import

### DIFF
--- a/planetio/models/res_config_settings.py
+++ b/planetio/models/res_config_settings.py
@@ -4,6 +4,10 @@ from odoo.exceptions import UserError
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
+    debug_import = fields.Boolean(string="Debug Excel Import",
+                                  config_parameter='planetio.debug_import',
+                                  default=True)
+
     gfw_email = fields.Char(string="GFW Email", config_parameter='planetio.gfw_email')
     gfw_password = fields.Char(string="GFW Password", config_parameter='planetio.gfw_password')
     gfw_org = fields.Char(string="GFW Organization", config_parameter='planetio.gfw_org', default='Planetio')

--- a/planetio/views/res_config_settings_view.xml
+++ b/planetio/views/res_config_settings_view.xml
@@ -9,6 +9,16 @@
     <xpath expr="//div[hasclass('settings')]" position="inside">
 
       <div class="app_settings_block" data-string="Planetio" data-key="planetio">
+        <div class="row mt16 o_settings_container" name="planetio_debug">
+          <div class="col-12 col-lg-12 o_setting_box">
+            <div class="o_setting_left_pane"/>
+            <div class="o_setting_right_pane">
+              <span class="o_form_label">Debug Excel Import</span>
+              <div class="text-muted"><field name="debug_import"/></div>
+            </div>
+          </div>
+        </div>
+
         <h2>Global Forest Watch API</h2>
         <div class="row mt16 o_settings_container" name="planetio_settings">
           <div class="col-12 col-lg-12 o_setting_box">

--- a/planetio/views/wizard_views.xml
+++ b/planetio/views/wizard_views.xml
@@ -23,21 +23,22 @@
           <group>
             <!-- STEP: UPLOAD -->
             <field name="step" invisible="1"/>
-            <group attrs="{'invisible':[('step','!=','upload')]}">
+            <field name="debug_import" invisible="1"/>
+            <group attrs="{'invisible':[('step','!=','upload')]}" >
               <field name="template_id" required="1"/>
               <field name="file_name" readonly="1"/>
               <field name="file_data" filename="file_name"/>
             </group>
 
             <!-- STEP: MAP -->
-            <group attrs="{'invisible':[('step','!=','map')]}">
+            <group attrs="{'invisible':['|',('step','!=','map'),('debug_import','=',False)]}">
               <field name="job_id" readonly="1"/>
               <field name="mapping_json" widget="text" string="Proposed Mapping" readonly="1"/>
               <field name="preview_json" widget="text" string="Preview (first rows)" readonly="1"/>
             </group>
 
             <!-- STEP: VALIDATE -->
-            <group attrs="{'invisible':[('step','!=','validate')]}">
+            <group attrs="{'invisible':['|',('step','!=','validate'),('debug_import','=',False)]}">
               <field name="result_json" widget="text" string="Validation Result" readonly="1"/>
             </group>
 
@@ -54,19 +55,19 @@
                   string="Analyze &amp; Map"
                   type="object"
                   class="btn-primary"
-                  attrs="{'invisible':[('step','!=','upload')]}"/>
+                  attrs="{'invisible':['|',('step','!=','upload'),('debug_import','=',False)]}"/>
 
           <button name="action_validate"
                   string="Validate"
                   type="object"
                   class="btn-primary"
-                  attrs="{'invisible':[('step','!=','map')]}"/>
+                  attrs="{'invisible':['|',('step','!=','map'),('debug_import','=',False)]}"/>
 
           <button name="action_confirm"
                   string="Create Records"
                   type="object"
                   class="btn-primary"
-                  attrs="{'invisible':[('step','!=','validate')]}"/>
+                  attrs="{'invisible':['|', '&', ('debug_import','=',True), ('step','!=','validate'), '&', ('debug_import','=',False), ('step','!=','upload')]}"/>
 
           <!-- Cancel during steps upload/map/validate -->
           <button string="Cancel"
@@ -75,7 +76,7 @@
                   attrs="{'invisible':[('step','=','confirm')]}"/>
 
           <!-- Nel gruppo dello step VALIDATE: mostra output -->
-          <field name="analysis_json" widget="text" string="External Analysis (per row)" readonly="1"/>
+          <field name="analysis_json" widget="text" string="External Analysis (per row)" readonly="1" attrs="{'invisible':[('debug_import','=',False)]}"/>
 
           <!-- Close on confirm -->
           <button string="Close"


### PR DESCRIPTION
## Summary
- Add configurable *Debug Excel Import* setting
- Skip mapping/validation in Excel import wizard when debug off
- Update wizard and settings views for new toggle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4b9b64af48333ae1450512911d936