### PR TITLE
Improve AI document summarization input handling

### DIFF
--- a/ai_gateway/services/ai_service.py
+++ b/ai_gateway/services/ai_service.py
@@ -1,25 +1,105 @@
 from odoo import models
 from .provider_gemini import GeminiProvider
 
+
 def _chunk_text(text, max_chars):
     if not text:
         return []
     chunks = []
     step = max(1000, max_chars)
     for i in range(0, len(text), step):
-        chunks.append(text[i:i+step])
+        chunks.append(text[i : i + step])
     return chunks
+
+
+def _decode_bytes(raw):
+    if not raw:
+        return ""
+    try:
+        return raw.decode("utf-8", errors="ignore")
+    except Exception:
+        return raw.decode("latin-1", errors="ignore")
+
+
+def _pdf_to_text(raw):
+    import io
+
+    if not raw:
+        return ""
+    buffer = io.BytesIO(raw)
+    try:  # pragma: no cover - optional dependency
+        from pdfminer.high_level import extract_text
+
+        return extract_text(buffer) or ""
+    except Exception:
+        buffer.seek(0)
+        try:  # pragma: no cover - optional dependency
+            import PyPDF2
+
+            reader = PyPDF2.PdfReader(buffer)
+            texts = []
+            for page in getattr(reader, "pages", []) or []:
+                page_text = page.extract_text() or ""
+                if page_text:
+                    texts.append(page_text)
+            return "\n".join(texts)
+        except Exception:
+            return ""
+
+
+def _docx_to_text(raw):
+    import io
+    import zipfile
+    from xml.etree import ElementTree
+
+    if not raw:
+        return ""
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            xml = zf.read("word/document.xml")
+    except Exception:
+        return ""
+
+    try:
+        ns = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+        root = ElementTree.fromstring(xml)
+        paragraphs = []
+        for para in root.findall(".//w:p", ns):
+            texts = [node.text for node in para.findall(".//w:t", ns) if node.text]
+            if texts:
+                paragraphs.append("".join(texts))
+        return "\n".join(paragraphs)
+    except Exception:
+        return ""
+
 
 def _attachment_to_text(env, att):
     import base64
-    mimetype = att.mimetype or ''
-    raw = base64.b64decode(att.datas or b'')
-    if mimetype.startswith('text/') or mimetype in ('application/json',):
-        try:
-            return raw.decode('utf-8', errors='ignore')
-        except Exception:
-            return raw.decode('latin-1', errors='ignore')
-    return ''
+
+    mimetype = (att.mimetype or "").lower()
+    name = (att.name or "").lower()
+    raw = base64.b64decode(att.datas or b"")
+
+    if mimetype.startswith("text/") or mimetype in ("application/json", "application/xml"):
+        return _decode_bytes(raw)
+
+    if mimetype == "application/pdf" or name.endswith(".pdf"):
+        return _pdf_to_text(raw)
+
+    if mimetype in (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    ) or name.endswith(".docx"):
+        text = _docx_to_text(raw)
+        if text:
+            return text
+        # legacy doc files might still be plain text when exported
+        return _decode_bytes(raw)
+
+    if mimetype in ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "text/csv") or name.endswith(".csv"):
+        return _decode_bytes(raw)
+
+    return ""
 
 class AiGatewayService(models.AbstractModel):
     _name = 'ai.gateway.service'
@@ -41,7 +121,8 @@ class AiGatewayService(models.AbstractModel):
             for att in req.attachment_ids:
                 txt = _attachment_to_text(self.env, att)
                 if txt:
-                    texts.append(txt)
+                    header = att.name or att.display_name or "Documento senza nome"
+                    texts.append(f"### {header}\n{txt}")
             full = "\n\n".join(texts) if texts else (req.payload or '')
             chunks = _chunk_text(full, max_chars)
             return provider.summarize_chunks(chunks, system_instruction=system_instruction)

--- a/planetio_ai/wizard/summarize_documents_wizard.py
+++ b/planetio_ai/wizard/summarize_documents_wizard.py
@@ -54,7 +54,13 @@ class PlanetioSummarizeWizard(models.Model):
                     "task_type": "summarize",
                     "attachment_ids": [(6, 0, rec.attachment_ids.ids)],
                     "model_ref": f"{rec._name},{rec.id}",
-                    "payload": "Estrarre un riepilogo con i dati rilevanti alla deforestazione.",
+                    "payload": (
+                        "Analizza tutti i documenti allegati relativi alla dichiarazione EUDR e "
+                        "riassumi le informazioni utili a valutare lo stato della deforestazione. "
+                        "La risposta finale deve includere bullet point chiari, lo stato della "
+                        "deforestazione, eventuali rischi o anomalie e, se disponibili dati "
+                        "numerici, una tabella in formato testo con gli indicatori principali."
+                    ),
                 }
             )
 

--- a/tests/test_ai_gateway_text_extraction.py
+++ b/tests/test_ai_gateway_text_extraction.py
@@ -1,0 +1,80 @@
+import base64
+import io
+import zipfile
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+class _FieldsStub(types.SimpleNamespace):
+    def __getattr__(self, name):  # pragma: no cover - defensive fallback
+        return lambda *args, **kwargs: None
+
+
+odoo = types.ModuleType("odoo")
+odoo.api = types.SimpleNamespace()
+odoo.fields = _FieldsStub()
+odoo.models = types.SimpleNamespace(Model=object, AbstractModel=object)
+sys.modules.setdefault("odoo", odoo)
+
+
+pkg_path = repo_root / "ai_gateway"
+services_path = pkg_path / "services"
+
+ai_gateway_pkg = types.ModuleType("ai_gateway")
+ai_gateway_pkg.__path__ = [str(pkg_path)]
+sys.modules.setdefault("ai_gateway", ai_gateway_pkg)
+
+services_pkg = types.ModuleType("ai_gateway.services")
+services_pkg.__path__ = [str(services_path)]
+sys.modules.setdefault("ai_gateway.services", services_pkg)
+
+
+spec = importlib.util.spec_from_file_location(
+    "ai_gateway.services.ai_service",
+    services_path / "ai_service.py",
+    submodule_search_locations=[str(services_path)],
+)
+ai_service = importlib.util.module_from_spec(spec)
+sys.modules["ai_gateway.services.ai_service"] = ai_service
+spec.loader.exec_module(ai_service)
+
+
+class DummyAttachment:
+    def __init__(self, raw_bytes, mimetype, name):
+        self.datas = base64.b64encode(raw_bytes).decode()
+        self.mimetype = mimetype
+        self.name = name
+        self.display_name = name
+
+
+def _make_docx(text):
+    xml = (
+        "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">"
+        "<w:body><w:p><w:r><w:t>" + text + "</w:t></w:r></w:p></w:body></w:document>"
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("word/document.xml", xml)
+    return buffer.getvalue()
+
+
+def test_plain_text_attachment_to_text():
+    att = DummyAttachment(b"Situazione deforestazione", "text/plain", "report.txt")
+    extracted = ai_service._attachment_to_text(None, att)
+    assert "Situazione deforestazione" in extracted
+
+
+def test_docx_attachment_to_text():
+    docx_bytes = _make_docx("Allerta deforestazione in crescita")
+    att = DummyAttachment(
+        docx_bytes,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "sintesi.docx",
+    )
+    extracted = ai_service._attachment_to_text(None, att)
+    assert "Allerta deforestazione" in extracted


### PR DESCRIPTION
## Summary
- decode PDF, DOCX and other structured attachments into text before sending them to the AI gateway and include document names in the synthesized prompt
- adjust the EUDR wizard prompt so the generated summary explicitly covers deforestation status, risks and bullet/table formatting
- add regression tests for the attachment text extraction helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8798e347883339a56773aca1efc78

## Summary by Sourcery

Improve AI document summarization by decoding structured attachments into text, prepending document headers, refining the wizard prompt requirements, and adding tests for extraction utilities

New Features:
- Support text extraction from PDF, DOCX and CSV attachments before sending them to the AI gateway
- Include attachment names as headers in the AI summarization input
- Refine the EUDR wizard prompt to explicitly require deforestation status, risks, bullet points, and numeric tables

Tests:
- Add regression tests for attachment text extraction helpers