### PR TITLE
Adjust EUDR area computation for point defaults

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+import sys
+import types
+
+
+odoo = sys.modules.setdefault('odoo', types.ModuleType('odoo'))
+
+
+class _Model:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+        pass
+
+    def __iter__(self):  # pragma: no cover - allows "for rec in self"
+        return iter([self])
+
+
+class _Field:
+    def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+        pass
+
+
+class _DatetimeField(_Field):
+    @staticmethod
+    def now():  # pragma: no cover - deterministic stub
+        return None
+
+
+models = getattr(odoo, 'models', types.SimpleNamespace())
+models.Model = getattr(models, 'Model', _Model)
+models.AbstractModel = getattr(models, 'AbstractModel', _Model)
+models.TransientModel = getattr(models, 'TransientModel', _Model)
+odoo.models = models
+
+
+fields = getattr(odoo, 'fields', types.SimpleNamespace())
+for name, value in {
+    'Binary': _Field,
+    'Boolean': _Field,
+    'Char': _Field,
+    'Datetime': _DatetimeField,
+    'Float': _Field,
+    'Integer': _Field,
+    'Many2one': _Field,
+    'One2many': _Field,
+    'Selection': _Field,
+    'Text': _Field,
+}.items():
+    if not hasattr(fields, name):
+        setattr(fields, name, value)
+odoo.fields = fields
+
+
+def _depends(*args, **kwargs):  # pragma: no cover - simple decorator stub
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+api = getattr(odoo, 'api', types.SimpleNamespace())
+api.depends = getattr(api, 'depends', _depends)
+api.model_create_multi = getattr(api, 'model_create_multi', lambda func: func)
+api.model = getattr(api, 'model', lambda func: func)
+odoo.api = api
+
+
+if not hasattr(odoo, '_'):
+    odoo._ = lambda s: s
+
+
+exceptions = types.ModuleType('odoo.exceptions')
+setattr(exceptions, 'UserError', Exception)
+sys.modules['odoo.exceptions'] = exceptions
+odoo.exceptions = exceptions

--- a/tests/test_eudr_area_compute.py
+++ b/tests/test_eudr_area_compute.py
@@ -1,0 +1,71 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root))
+
+
+module_path = repo_root / 'planetio' / 'models' / 'eudr_models.py'
+spec = importlib.util.spec_from_file_location('eudr_models', module_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+EUDRDeclaration = mod.EUDRDeclaration
+
+
+def _make_line(geometry_dict):
+    return types.SimpleNamespace(geometry=json.dumps(geometry_dict))
+
+
+def _make_record(lines):
+    rec = EUDRDeclaration()
+    rec.line_ids = lines
+    rec.area_ha = 0.0
+    return rec
+
+
+def test_single_point_uses_four_square_meters():
+    rec = _make_record([
+        _make_line({"type": "Point", "coordinates": [0.0, 0.0]}),
+    ])
+
+    rec._compute_area_ha()
+
+    assert rec.area_ha == pytest.approx(4.0 / 10000.0)
+
+
+def test_polygon_and_point_are_summed():
+    polygon = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [0.0, 0.0],
+                [0.001, 0.0],
+                [0.001, 0.001],
+                [0.0, 0.001],
+                [0.0, 0.0],
+            ]
+        ],
+    }
+
+    polygon_record = _make_record([_make_line(polygon)])
+    polygon_record._compute_area_ha()
+
+    combined_record = _make_record([
+        _make_line(polygon),
+        _make_line({"type": "Point", "coordinates": [0.0, 0.0]}),
+    ])
+    combined_record._compute_area_ha()
+
+    assert combined_record.area_ha > polygon_record.area_ha
+    assert combined_record.area_ha == pytest.approx(
+        polygon_record.area_ha + 4.0 / 10000.0,
+        rel=1e-3,
+    )


### PR DESCRIPTION
## Summary
- adjust the EUDR declaration area compute to sum per-line areas, using 4 m² defaults for point geometries and computing polygon areas via a shared helper
- add a pytest conftest Odoo stub and regression tests covering point and polygon combinations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c986813b7883339f7a2b14839d915a