### PR TITLE
Translate Italian localizations

### DIFF
--- a/ai_gateway/i18n/it.po
+++ b/ai_gateway/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* ai_gateway
+#       * ai_gateway
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,168 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: ai_gateway
+#: model:ir.model,name:ai_gateway.model_ai_request
+msgid "AI Request"
+msgstr "Richiesta AI"
+
+#. module: ai_gateway
+#: model:ir.model,name:ai_gateway.model_ai_gateway_service
+msgid "AI Gateway Service"
+msgstr "Servizio AI Gateway"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__provider
+msgid "Provider"
+msgstr "Provider"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__task_type
+msgid "Task Type"
+msgstr "Tipo di attivit\u00e0"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__status
+msgid "Status"
+msgstr "Stato"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__model_ref
+msgid "Model Ref"
+msgstr "Riferimento modello"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__payload
+msgid "Payload"
+msgstr "Payload"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__duration_ms
+msgid "Duration Ms"
+msgstr "Durata (ms)"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_ai_request__cost_estimate
+msgid "Cost Estimate"
+msgstr "Stima costi"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_res_config_settings__ai_gemini_api_key
+msgid "Gemini API Key"
+msgstr "Chiave API Gemini"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_res_config_settings__ai_gemini_model
+msgid "Gemini Model name"
+msgstr "Nome modello Gemini"
+
+#. module: ai_gateway
+#: model:ir.model.fields,field_description:ai_gateway.field_res_config_settings__ai_max_chunk_chars
+msgid "Max chars per chunk"
+msgstr "Caratteri massimi per blocco"
+
+#. module: ai_gateway
+#: selection:ai.request,provider
+msgid "Gemini"
+msgstr "Gemini"
+
+#. module: ai_gateway
+#: selection:ai.request,task_type
+msgid "Chat/Generate"
+msgstr "Chat/Generazione"
+
+#. module: ai_gateway
+#: selection:ai.request,task_type
+msgid "Summarize"
+msgstr "Riassumi"
+
+#. module: ai_gateway
+#: selection:ai.request,task_type
+msgid "Classify"
+msgstr "Classifica"
+
+#. module: ai_gateway
+#: selection:ai.request,task_type
+msgid "Embed"
+msgstr "Genera embedding"
+
+#. module: ai_gateway
+#: selection:ai.request,status
+msgid "Draft"
+msgstr "Bozza"
+
+#. module: ai_gateway
+#: selection:ai.request,status
+msgid "Running"
+msgstr "In esecuzione"
+
+#. module: ai_gateway
+#: selection:ai.request,status
+msgid "Done"
+msgstr "Completata"
+
+#. module: ai_gateway
+#: selection:ai.request,status
+msgid "Error"
+msgstr "Errore"
+
+#. module: ai_gateway
+#: selection:ai.request,status
+msgid "Queued"
+msgstr "In coda"
+
+#. module: ai_gateway
+#: model:ir.actions.act_window,name:ai_gateway.action_ai_request
+msgid "AI Requests"
+msgstr "Richieste AI"
+
+#. module: ai_gateway
+#: model:ir.ui.menu,name:ai_gateway.menu_ai_root
+msgid "AI"
+msgstr "AI"
+
+#. module: ai_gateway
+#: model:ir.ui.menu,name:ai_gateway.menu_ai_requests
+msgid "Requests"
+msgstr "Richieste"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_ai_request_form
+msgid "AI Request"
+msgstr "Richiesta AI"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_ai_request_tree
+msgid "AI Requests"
+msgstr "Richieste AI"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_res_config_settings_ai_gateway
+msgid "AI Gateway"
+msgstr "AI Gateway"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_res_config_settings_ai_gateway
+msgid "Default provider"
+msgstr "Provider predefinito"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_res_config_settings_ai_gateway
+msgid "Gemini API key"
+msgstr "Chiave API Gemini"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_res_config_settings_ai_gateway
+msgid "Gemini model"
+msgstr "Modello Gemini"
+
+#. module: ai_gateway
+#: model_terms:ir.ui.view,arch_db:ai_gateway.view_res_config_settings_ai_gateway
+msgid "Max chunk chars"
+msgstr "Caratteri massimi per blocco"
+
+#. module: ai_gateway
+#: model:ir.actions.act_window,name:ai_gateway.action_planetio_config_settings
+msgid "AI Gateway Settings"
+msgstr "Impostazioni AI Gateway"

--- a/coffee_species/i18n/it.po
+++ b/coffee_species/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* coffee_species
+#       * coffee_species
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,209 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: coffee_species
+#: model:ir.model,name:coffee_species.model_coffee_species
+msgid "Coffee Species"
+msgstr "Specie di caff\u00e8"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__name
+msgid "Common Name"
+msgstr "Nome comune"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__scientific_name
+msgid "Scientific Name"
+msgstr "Nome scientifico"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__synonyms
+msgid "Synonyms"
+msgstr "Sinonimi"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__is_commercial
+msgid "Commercially Cultivated"
+msgstr "Coltivato commercialmente"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__region
+msgid "Region/Origin"
+msgstr "Regione/origine"
+
+#. module: coffee_species
+#: model:ir.model.fields,field_description:coffee_species.field_coffee_species__notes
+msgid "Notes"
+msgstr "Note"
+
+#. module: coffee_species
+#: model:ir.model.constraint,message:coffee_species.constraint_coffee_species_scientific_name_uniq
+msgid "Scientific name must be unique."
+msgstr "Il nome scientifico deve essere univoco."
+
+#. module: coffee_species
+#: model:ir.actions.act_window,name:coffee_species.action_coffee_species
+#: model:ir.ui.menu,name:coffee_species.menu_coffee_species
+msgid "Coffee Species"
+msgstr "Specie di caff\u00e8"
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_form
+msgid "Notes"
+msgstr "Note"
+
+#. module: coffee_species
+#: model_terms:ir.actions.act_window,help:coffee_species.action_coffee_species
+msgid "Add and manage coffee species, with common and scientific names."
+msgstr "Aggiungi e gestisci le specie di caff\u00e8, con nomi comuni e scientifici."
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_search
+msgid "Commercial"
+msgstr "Commerciale"
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_search
+msgid "Active"
+msgstr "Attivo"
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_search
+msgid "Active species"
+msgstr "Specie attive"
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_search
+msgid "Group By"
+msgstr "Raggruppa per"
+
+#. module: coffee_species
+#: model_terms:ir.ui.view,arch_db:coffee_species.view_coffee_species_search
+msgid "Region"
+msgstr "Regione"
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_arabica
+msgid "Arabica coffee"
+msgstr "Caff\u00e8 Arabica"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_arabica
+msgid "Ethiopia / Yemen (origins)"
+msgstr "Etiopia / Yemen (origini)"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_arabica
+msgid "Most widely consumed; generally sweeter and more acidic."
+msgstr "La pi\u00f9 consumata; generalmente pi\u00f9 dolce e acida."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_robusta
+msgid "Robusta coffee"
+msgstr "Caff\u00e8 Robusta"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_robusta
+msgid "Central &amp; West Africa (origins)"
+msgstr "Africa centrale e occidentale (origini)"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_robusta
+msgid "Higher caffeine; stronger, more bitter profile."
+msgstr "Pi\u00f9 caffeina; profilo pi\u00f9 forte e amaro."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_liberica
+msgid "Liberica coffee"
+msgstr "Caff\u00e8 Liberica"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_liberica
+msgid "West &amp; Central Africa (origins)"
+msgstr "Africa occidentale e centrale (origini)"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_liberica
+msgid "Distinct fruity/woody notes; larger beans."
+msgstr "Note fruttate/legnose marcate; chicchi pi\u00f9 grandi."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_excelsa
+msgid "Excelsa coffee"
+msgstr "Caff\u00e8 Excelsa"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_excelsa
+msgid "Central Africa (origins)"
+msgstr "Africa centrale (origini)"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_excelsa
+msgid "Often classified under Liberica; tart, complex."
+msgstr "Spesso classificata sotto Liberica; acidula e complessa."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_stenophylla
+msgid "Stenophylla coffee"
+msgstr "Caff\u00e8 Stenophylla"
+
+#. module: coffee_species
+#: model:coffee.species,synonyms:coffee_species.coffee_species_stenophylla
+msgid "Highland coffee"
+msgstr "Caff\u00e8 di montagna"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_stenophylla
+msgid "West Africa"
+msgstr "Africa occidentale"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_stenophylla
+msgid "Heat-tolerant; renewed interest for climate resilience."
+msgstr "Tollerante al calore; rinnovato interesse per la resilienza climatica."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_mauritiana
+msgid "Mauritius coffee"
+msgstr "Caff\u00e8 Mauritius"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_mauritiana
+msgid "Mascarenes"
+msgstr "Mascarene"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_mauritiana
+msgid "Wild/rare."
+msgstr "Selvatico/raro."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_congensis
+msgid "Congo coffee"
+msgstr "Caff\u00e8 del Congo"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_congensis
+msgid "Congo Basin"
+msgstr "Bacino del Congo"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_congensis
+msgid "Wild/limited cultivation."
+msgstr "Selvatico/coltivazione limitata."
+
+#. module: coffee_species
+#: model:coffee.species,name:coffee_species.coffee_species_afrikana
+msgid "Sierra Leone coffee"
+msgstr "Caff\u00e8 della Sierra Leone"
+
+#. module: coffee_species
+#: model:coffee.species,region:coffee_species.coffee_species_afrikana
+msgid "Sierra Leone"
+msgstr "Sierra Leone"
+
+#. module: coffee_species
+#: model:coffee.species,notes:coffee_species.coffee_species_afrikana
+msgid "Rare; sometimes treated under C. stenophylla in literature."
+msgstr "Raro; talvolta considerato parte di C. stenophylla in letteratura."

--- a/planetio/i18n/it.po
+++ b/planetio/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* planetio
+#       * planetio
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,793 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_eudr_stage
+msgid "CRM Stages"
+msgstr "Fasi CRM"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_eudr_declaration
+msgid "EUDR Declaration"
+msgstr "Dichiarazione EUDR"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_eudr_declaration_line
+msgid "EUDR Declaration Line"
+msgstr "Riga dichiarazione EUDR"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_excel_import_template
+msgid "Excel Import Template"
+msgstr "Template import Excel"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_excel_import_template_field
+msgid "Excel Import Template Field"
+msgstr "Campo del template di importazione Excel"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_excel_import_service
+msgid "Excel Import Service (EUDR-aware)"
+msgstr "Servizio di importazione Excel (compatibile EUDR)"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_excel_import_wizard
+msgid "Excel Import Wizard"
+msgstr "Procedura guidata import Excel"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_excel_import_transformers
+msgid "Excel Import Transformers"
+msgstr "Trasformatori importazione Excel"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_deforestation_service
+msgid "Deforestation Service Orchestrator"
+msgstr "Orchestratore servizio deforestazione"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_deforestation_provider_base
+msgid "Base provider interface"
+msgstr "Interfaccia provider di base"
+
+#. module: planetio
+#: model:ir.model,name:planetio.model_deforestation_provider_gfw
+msgid "Deforestation Provider - GFW"
+msgstr "Provider deforestazione - GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_stage__name
+msgid "Stage Name"
+msgstr "Nome fase"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_stage__sequence
+msgid "Sequence"
+msgstr "Sequenza"
+
+#. module: planetio
+#: model:ir.model.fields,help:planetio.field_eudr_stage__sequence
+msgid "Used to order stages. Lower is better."
+msgstr "Utilizzato per ordinare le fasi. I valori più bassi hanno priorit\u00e0."
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__datestamp
+msgid "Datestamp"
+msgstr "Data e ora"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__partner_id
+msgid "Partner"
+msgstr "Partner"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__dds_identifier
+msgid "DDS Identifier (UUID)"
+msgstr "Identificativo DDS (UUID)"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__stage_id
+msgid "Stage"
+msgstr "Fase"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__line_ids
+msgid "Lines"
+msgstr "Righe"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__attachment_ids
+msgid "Attachments"
+msgstr "Allegati"
+
+#. module: planetio
+#: model:ir.model.fields,help:planetio.field_eudr_declaration__attachment_ids
+msgid "Files linked to this declaration."
+msgstr "File collegati a questa dichiarazione."
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__eudr_company_type
+msgid "Company Type"
+msgstr "Tipologia azienda"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__eudr_type_override
+msgid "Operator"
+msgstr "Operatore"
+
+#. module: planetio
+#: model:ir.model.fields,help:planetio.field_eudr_declaration__eudr_type_override
+msgid "Specify whether you're acting as Trader or Operator for this batch."
+msgstr "Specifica se operi come Trader o Operatore per questo lotto."
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__eudr_third_party_client_id
+msgid "Client (3rd Party Trader)"
+msgstr "Cliente (trader terza parte)"
+
+#. module: planetio
+#: model:ir.model.fields,help:planetio.field_eudr_declaration__eudr_third_party_client_id
+msgid "Client on behalf of whom the DDS is being submitted."
+msgstr "Cliente per conto del quale viene inviata la DDS."
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__activity_type
+msgid "Activity"
+msgstr "Attivit\u00e0"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__operator_name
+msgid "Operator"
+msgstr "Operatore"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__extra_info
+msgid "Additional info"
+msgstr "Informazioni aggiuntive"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__hs_code
+msgid "HS Code"
+msgstr "Codice HS"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__product_id
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__product_description
+msgid "Description of raw materials or products"
+msgstr "Descrizione delle materie prime o dei prodotti"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__net_mass_kg
+msgid "Net weight"
+msgstr "Peso netto"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__common_name
+msgid "Common name"
+msgstr "Nome comune"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__producer_name
+msgid "Producer name"
+msgstr "Nome del produttore"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration__coffee_species
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration_line__defor_provider
+msgid "Deforestation Provider"
+msgstr "Provider deforestazione"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration_line__defor_alerts
+msgid "Deforestation Alerts"
+msgstr "Allerte deforestazione"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration_line__defor_area_ha
+msgid "Deforestation Area (ha)"
+msgstr "Area deforestazione (ha)"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_eudr_declaration_line__defor_details_json
+msgid "Deforestation Details (JSON)"
+msgstr "Dettagli deforestazione (JSON)"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_excel_import_template__strictness_level
+msgid "Strictness Level"
+msgstr "Livello di rigidit\u00e0"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_excel_import_wizard__file_data
+msgid "File"
+msgstr "File"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_excel_import_wizard__file_name
+msgid "Filename"
+msgstr "Nome file"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__debug_import
+msgid "Debug Excel Import"
+msgstr "Debug import Excel"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__gfw_email
+msgid "GFW Email"
+msgstr "Email GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__gfw_password
+msgid "GFW Password"
+msgstr "Password GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__gfw_org
+msgid "GFW Organization"
+msgstr "Organizzazione GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__gfw_alias
+msgid "GFW API Alias"
+msgstr "Alias API GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__gfw_api_key
+msgid "GFW API Key"
+msgstr "Chiave API GFW"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__eudr_endpoint
+msgid "EUDR Endpoint"
+msgstr "Endpoint EUDR"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__eudr_user
+msgid "EUDR User"
+msgstr "Utente EUDR"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__eudr_apikey
+msgid "api-key"
+msgstr "Chiave API"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__eudr_wsse_mode
+msgid "WSSE mode"
+msgstr "Modalit\u00e0 WSSE"
+
+#. module: planetio
+#: model:ir.model.fields,field_description:planetio.field_res_config_settings__eudr_webservice_client_id
+msgid "Client ID"
+msgstr "ID client"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_company_type
+msgid "Trader"
+msgstr "Trader"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_company_type
+msgid "Operator"
+msgstr "Operatore"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_company_type
+msgid "Mixed"
+msgstr "Misto"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_company_type
+msgid "Third-party Trader"
+msgstr "Trader di terze parti"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_type_override
+msgid "Trader"
+msgstr "Trader"
+
+#. module: planetio
+#: selection:eudr.declaration,eudr_type_override
+msgid "Operator"
+msgstr "Operatore"
+
+#. module: planetio
+#: selection:eudr.declaration,activity_type
+msgid "Import"
+msgstr "Importazione"
+
+#. module: planetio
+#: selection:eudr.declaration,activity_type
+msgid "Export"
+msgstr "Esportazione"
+
+#. module: planetio
+#: selection:eudr.declaration,activity_type
+msgid "Domestic"
+msgstr "Mercato interno"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 \u2013 Coffee, whether or not roasted or decaffeinated; coffee husks and skins; coffee substitutes containing coffee"
+msgstr "0901 \u2013 Caff\u00e8, tostato o meno, decaffeinato o meno; cascami e bucce di caff\u00e8; surrogati contenenti caff\u00e8"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 11 \u2013 non-decaffeinated"
+msgstr "0901 11 \u2013 non decaffeinato"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 12 \u2013 decaffeinated"
+msgstr "0901 12 \u2013 decaffeinato"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 21 \u2013 non-decaffeinated"
+msgstr "0901 21 \u2013 non decaffeinato"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 22 \u2013 decaffeinated"
+msgstr "0901 22 \u2013 decaffeinato"
+
+#. module: planetio
+#: selection:eudr.declaration,hs_code
+msgid "0901 90 \u2013 others"
+msgstr "0901 90 \u2013 altri"
+
+#. module: planetio
+#: selection:eudr.declaration.line,geo_type
+msgid "Point"
+msgstr "Punto"
+
+#. module: planetio
+#: selection:eudr.declaration.line,geo_type
+msgid "Polygon"
+msgstr "Poligono"
+
+#. module: planetio
+#: selection:eudr.declaration.line,external_status
+msgid "OK"
+msgstr "OK"
+
+#. module: planetio
+#: selection:eudr.declaration.line,external_status
+msgid "Pass"
+msgstr "Superato"
+
+#. module: planetio
+#: selection:eudr.declaration.line,external_status
+msgid "Fail"
+msgstr "Non superato"
+
+#. module: planetio
+#: selection:eudr.declaration.line,external_status
+msgid "Error"
+msgstr "Errore"
+
+#. module: planetio
+#: selection:excel.import.template,strictness_level
+msgid "Low"
+msgstr "Basso"
+
+#. module: planetio
+#: selection:excel.import.template,strictness_level
+msgid "Medium"
+msgstr "Medio"
+
+#. module: planetio
+#: selection:excel.import.template,strictness_level
+msgid "High"
+msgstr "Alto"
+
+#. module: planetio
+#: selection:excel.import.template.field,selector_policy
+msgid "By Header"
+msgstr "Per intestazione"
+
+#. module: planetio
+#: selection:excel.import.template.field,selector_policy
+msgid "By Regex"
+msgstr "Per regex"
+
+#. module: planetio
+#: selection:excel.import.template.field,selector_policy
+msgid "By AI"
+msgstr "Con IA"
+
+#. module: planetio
+#: selection:excel.import.wizard,step
+msgid "Upload"
+msgstr "Caricamento"
+
+#. module: planetio
+#: selection:excel.import.wizard,step
+msgid "Mapping"
+msgstr "Mappatura"
+
+#. module: planetio
+#: selection:excel.import.wizard,step
+msgid "Validate"
+msgstr "Convalida"
+
+#. module: planetio
+#: selection:excel.import.wizard,step
+msgid "Confirm"
+msgstr "Conferma"
+
+#. module: planetio
+#: model:eudr.stage,name:planetio.eudr_stage_draft
+msgid "Draft"
+msgstr "Bozza"
+
+#. module: planetio
+#: model:eudr.stage,name:planetio.eudr_stage_validated
+msgid "Validated"
+msgstr "Validata"
+
+#. module: planetio
+#: model:eudr.stage,name:planetio.eudr_stage_sent
+msgid "Sent"
+msgstr "Inviata"
+
+#. module: planetio
+#: model:eudr.stage,name:planetio.eudr_stage_completed
+msgid "Completed"
+msgstr "Completata"
+
+#. module: planetio
+#: model:excel.import.template,name:planetio.tmpl_eudr_declaration
+#: model:ir.sequence,name:planetio.seq_eudr_declaration
+msgid "EUDR Declaration"
+msgstr "Dichiarazione EUDR"
+
+#. module: planetio
+#: model:ir.actions.act_window,name:planetio.action_eudr_declaration
+msgid "EUDR Declarations"
+msgstr "Dichiarazioni EUDR"
+
+#. module: planetio
+#: model:ir.actions.act_window,name:planetio.action_eudr_stage
+msgid "EUDR Stages"
+msgstr "Fasi EUDR"
+
+#. module: planetio
+#: model:ir.ui.menu,name:planetio.menu_eudr_ai_root
+msgid "Planetio"
+msgstr "Planetio"
+
+#. module: planetio
+#: model:ir.ui.menu,name:planetio.menu_eudr_declarations
+msgid "Declarations"
+msgstr "Dichiarazioni"
+
+#. module: planetio
+#: model:ir.ui.menu,name:planetio.menu_eudr_stage_root
+msgid "Stage"
+msgstr "Fase"
+
+#. module: planetio
+#: model:ir.actions.act_window,name:planetio.action_excel_import_template
+msgid "Import Templates"
+msgstr "Template di importazione"
+
+#. module: planetio
+#: model:ir.ui.menu,name:planetio.menu_eudr_settings
+msgid "Settings"
+msgstr "Impostazioni"
+
+#. module: planetio
+#: model:ir.ui.menu,name:planetio.menu_templates
+msgid "Templates"
+msgstr "Template"
+
+#. module: planetio
+#: model:ir.actions.act_window,name:planetio.action_excel_import_wizard
+msgid "Excel Import Wizard"
+msgstr "Procedura guidata import Excel"
+
+#. module: planetio
+#: model:ir.actions.act_window,name:planetio.action_planetio_config_settings
+msgid "Planetio Settings"
+msgstr "Impostazioni Planetio"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "EUDR Declaration"
+msgstr "Dichiarazione EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Import"
+msgstr "Importa"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Deforestation analysis"
+msgstr "Analisi deforestazione"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Trasmit DDS"
+msgstr "Trasmetti DDS"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Eudr sequence"
+msgstr "Sequenza EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Creation date"
+msgstr "Data creazione"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "EUDR Reference"
+msgstr "Riferimento EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Internal Ref"
+msgstr "Rif. interno"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Details"
+msgstr "Dettagli"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Message"
+msgstr "Messaggio"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Show point on map"
+msgstr "Mostra punto sulla mappa"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Show area on map"
+msgstr "Mostra area sulla mappa"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Farm data"
+msgstr "Dati azienda agricola"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Geo data"
+msgstr "Dati geografici"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Additional api data"
+msgstr "Dati API aggiuntivi"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "External Message (full)"
+msgstr "Messaggio esterno (completo)"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Documents"
+msgstr "Documenti"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Attachments"
+msgstr "Allegati"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Attachment"
+msgstr "Allegato"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_eudr_declaration_form
+msgid "Additional info"
+msgstr "Informazioni aggiuntive"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_template_form
+msgid "Import Template"
+msgstr "Template di importazione"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_template_form
+msgid "Fields"
+msgstr "Campi"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_template_tree
+msgid "Import Templates"
+msgstr "Template di importazione"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Excel Import"
+msgstr "Importazione Excel"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Proposed Mapping"
+msgstr "Mappatura proposta"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Preview (first rows)"
+msgstr "Anteprima (prime righe)"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Validation Result"
+msgstr "Risultato della convalida"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Analyze &amp; Map"
+msgstr "Analizza e mappa"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Validate"
+msgstr "Convalida"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Create Records"
+msgstr "Crea record"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Cancel"
+msgstr "Annulla"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "External Analysis (per row)"
+msgstr "Analisi esterna (per riga)"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.view_excel_import_wizard_form
+msgid "Close"
+msgstr "Chiudi"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Planetio"
+msgstr "Planetio"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Debug Excel Import"
+msgstr "Debug import Excel"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Global Forest Watch API"
+msgstr "API Global Forest Watch"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "GreenForestWatch User"
+msgstr "Utente GreenForestWatch"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "GreenForestWatch Password"
+msgstr "Password GreenForestWatch"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Organization"
+msgstr "Organizzazione"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Alias"
+msgstr "Alias"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "API Key"
+msgstr "Chiave API"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Genera/Aggiorna API key"
+msgstr "Genera/Aggiorna API key"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "TRACES EUDR API"
+msgstr "API TRACES EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "User TRACES EUDR"
+msgstr "Utente TRACES EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Authentication Key TRACES EUDR"
+msgstr "Chiave di autenticazione TRACES EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Webservice access identifier TRACES EUDR"
+msgstr "Identificativo accesso webservice TRACES EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "Endpoint URL TRACES EUDR"
+msgstr "URL endpoint TRACES EUDR"
+
+#. module: planetio
+#: model_terms:ir.ui.view,arch_db:planetio.planetio_res_config_settings_view
+msgid "DDS submission WSDL Method TRACES EUDR"
+msgstr "Metodo WSDL invio DDS TRACES EUDR"
+
+#. module: planetio
+#: code:addons/planetio/models/eudr_models.py:0
+#, python-format
+msgid "New"
+msgstr "Nuovo"
+
+#. module: planetio
+#: code:addons/planetio/models/eudr_models.py:0
+msgid "OTP sent to the phone number entered during certification."
+msgstr "OTP inviato al numero di telefono indicato durante la certificazione."
+
+#. module: planetio
+#: code:addons/planetio/models/eudr_deforestation.py:0
+#, python-format
+msgid "Data API HTTP %(code)s: step=%(s)s; body=%(b)s"
+msgstr "API dati HTTP %(code)s: step=%(s)s; body=%(b)s"
+
+#. module: planetio
+#: code:addons/planetio/services/eudr_adapter_odoo.py:0
+#, python-format
+msgid "Submission for %s on %s by %s"
+msgstr "Invio per %s il %s da %s"
+
+#. module: planetio
+#: code:addons/planetio/services/eudr_adapter_odoo.py:0
+msgid "net_weight must be a valid number (kg)"
+msgstr "net_weight deve essere un numero valido (kg)"
+
+#. module: planetio
+#: code:addons/planetio/services/eudr_adapter_odoo.py:0
+msgid "net_weight must be > 0 kg"
+msgstr "net_weight deve essere > 0 kg"
+
+#. module: planetio
+#: code:addons/planetio/services/deforestation_service.py:0
+msgid "OK"
+msgstr "OK"
+
+#. module: planetio
+#: code:addons/planetio/wizards/import_wizard.py:0
+#, python-format
+msgid "Invalid GeoJSON file: %s"
+msgstr "File GeoJSON non valido: %s"
+
+#. module: planetio
+#: code:addons/planetio/wizards/import_wizard.py:0
+msgid "Invalid GeoJSON file"
+msgstr "File GeoJSON non valido"

--- a/planetio_ai/i18n/it.po
+++ b/planetio_ai/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* planetio_ai
+#       * planetio_ai
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,156 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.view_eudr_declaration_form_ai
+msgid "AI Analyze"
+msgstr "Analisi AI"
+
+#. module: planetio_ai
+#: model:ir.actions.report,name:planetio_ai.action_report_ai_summary
+msgid "AI Summary"
+msgstr "Riepilogo AI"
+
+#. module: planetio_ai
+#: model:ir.actions.report,print_report_name:planetio_ai.action_report_ai_summary
+msgid "AI Summary - %s"
+msgstr "Riepilogo AI - %s"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary_document
+msgid "AI Document Summary"
+msgstr "Riepilogo documentale AI"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary_document
+msgid "Declaration"
+msgstr "Dichiarazione"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary_document
+msgid "Generated on"
+msgstr "Generato il"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary_document
+msgid "No summary content was returned by the AI service."
+msgstr "Il servizio AI non ha restituito alcun contenuto riassuntivo."
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary_document
+msgid "Original AI response"
+msgstr "Risposta AI originale"
+
+#. module: planetio_ai
+#: model_terms:ir.ui.view,arch_db:planetio_ai.report_ai_summary
+msgid "AI Summary"
+msgstr "Riepilogo AI"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "AI Document Summary"
+msgstr "Riepilogo documentale AI"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Declaration"
+msgstr "Dichiarazione"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Generated on"
+msgstr "Generato il"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Original AI response"
+msgstr "Risposta AI originale"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "No summary content was returned by the AI service."
+msgstr "Il servizio AI non ha restituito alcun contenuto riassuntivo."
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Deforestation alerts summary"
+msgstr "Riepilogo allerte deforestazione"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+#, python-format
+msgid "%(count)s alert(s) detected across %(lines)s line(s)."
+msgstr "%(count)s allerta/e rilevate su %(lines)s riga/e."
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "The latest deforestation analysis reported no alerts for the processed lines."
+msgstr "L'ultima analisi sulla deforestazione non ha segnalato allerte per le righe elaborate."
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Line"
+msgstr "Riga"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Provider"
+msgstr "Provider"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Alerts"
+msgstr "Allerte"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Area (ha)"
+msgstr "Area (ha)"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Message"
+msgstr "Messaggio"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+#, python-format
+msgid "Alerts for %s"
+msgstr "Allerte per %s"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+#, python-format
+msgid "...and %(count)s more alert(s)."
+msgstr "...e altre %(count)s allerte."
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Alert ID"
+msgstr "ID allerta"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Date"
+msgstr "Data"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Start date"
+msgstr "Data iniziale"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "End date"
+msgstr "Data finale"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Confidence"
+msgstr "Affidabilit\u00e0"
+
+#. module: planetio_ai
+#: code:addons/planetio_ai/wizard/summarize_documents_wizard.py:0
+msgid "Intensity"
+msgstr "Intensit\u00e0"

--- a/planetio_lots/i18n/it.po
+++ b/planetio_lots/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* planetio_lots
+#       * planetio_lots
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: planetio_lots
+#: model:ir.model.fields,field_description:planetio_lots.field_eudr_declaration__stock_lot_id
+msgid "Stock Lot"
+msgstr "Lotto di magazzino"
+
+#. module: planetio_lots
+#: model:ir.model.fields,help:planetio_lots.field_eudr_declaration__stock_lot_id
+msgid "Select an existing stock lot to link with this declaration."
+msgstr "Seleziona un lotto di magazzino esistente da collegare a questa dichiarazione."

--- a/planetio_osapiens/i18n/it.po
+++ b/planetio_osapiens/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* planetio_osapiens
+#       * planetio_osapiens
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,78 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_purchase_order__osapiens_lot_id
+msgid "oSapiens Lot ID"
+msgstr "ID lotto oSapiens"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_purchase_order__osapiens_dds_reference
+msgid "DDS Reference"
+msgstr "Riferimento DDS"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_purchase_order__osapiens_dds_status
+msgid "DDS Status"
+msgstr "Stato DDS"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_res_config_settings__osapiens_base_url
+msgid "oSapiens Base URL"
+msgstr "URL base oSapiens"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_res_config_settings__osapiens_account_id
+msgid "oSapiens Account ID"
+msgstr "ID account oSapiens"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_res_config_settings__osapiens_api_token
+msgid "oSapiens API Token"
+msgstr "Token API oSapiens"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_res_config_settings__osapiens_timeout
+msgid "oSapiens Timeout (s)"
+msgstr "Timeout oSapiens (s)"
+
+#. module: planetio_osapiens
+#: model:ir.model.fields,field_description:planetio_osapiens.field_res_config_settings__osapiens_verify_ssl
+msgid "oSapiens Verify SSL"
+msgstr "Verifica SSL oSapiens"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "oSapiens API"
+msgstr "API oSapiens"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "oSapiens base url"
+msgstr "URL base oSapiens"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "Account"
+msgstr "Account"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "Api-key/Token"
+msgstr "API key/Token"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "Timeout"
+msgstr "Timeout"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.res_config_settings_view_form_osapiens
+msgid "SSL"
+msgstr "SSL"
+
+#. module: planetio_osapiens
+#: model_terms:ir.ui.view,arch_db:planetio_osapiens.view_purchase_order_form_osapiens
+msgid "oSapiens"
+msgstr "oSapiens"

--- a/planetio_surveys/i18n/it.po
+++ b/planetio_surveys/i18n/it.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* planetio_surveys
+#       * planetio_surveys
 #
 msgid ""
 msgstr ""
@@ -15,3 +15,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: planetio_surveys
+#: model:ir.actions.act_window,name:planetio_surveys.action_eudr_declaration_survey_user_input
+#: model_terms:ir.ui.view,arch_db:planetio_surveys.view_eudr_declaration_form_inherit_surveys
+msgid "Questionnaires"
+msgstr "Questionari"
+
+#. module: planetio_surveys
+#: model:ir.model.fields,field_description:planetio_surveys.field_eudr_declaration__survey_user_input_ids
+#: model:ir.model.fields,field_description:planetio_surveys.field_eudr_declaration__survey_user_input_count
+msgid "Questionnaires"
+msgstr "Questionari"
+
+#. module: planetio_surveys
+#: model:ir.model.fields,field_description:planetio_surveys.field_survey_user_input__declaration_id
+msgid "Declaration"
+msgstr "Dichiarazione"
+
+#. module: planetio_surveys
+#: model:survey.survey,title:planetio_surveys.survey_eudr_questionnaire
+msgid "EUDR Test Survey"
+msgstr "Questionario di prova EUDR"
+
+#. module: planetio_surveys
+#: model:survey.survey,description:planetio_surveys.survey_eudr_questionnaire
+msgid "Minimal survey to test loading."
+msgstr "Questionario minimale per testare il caricamento."
+
+#. module: planetio_surveys
+#: model:survey.question,title:planetio_surveys.survey_eudr_page_intro
+msgid "Introduction Page"
+msgstr "Pagina introduttiva"
+
+#. module: planetio_surveys
+#: model:survey.question,title:planetio_surveys.survey_eudr_q_test
+msgid "Do you see this question?"
+msgstr "Visualizzi questa domanda?"
+
+#. module: planetio_surveys
+#: model:survey.question,constr_error_msg:planetio_surveys.survey_eudr_q_test
+msgid "Please choose an option."
+msgstr "Seleziona un'opzione."
+
+#. module: planetio_surveys
+#: model:survey.question.answer,value:planetio_surveys.survey_eudr_q_test_yes
+msgid "Yes"
+msgstr "S\u00ec"
+
+#. module: planetio_surveys
+#: model:survey.question.answer,value:planetio_surveys.survey_eudr_q_test_no
+msgid "No"
+msgstr "No"


### PR DESCRIPTION
## Summary
- Localized the Planetio core module to Italian across models, menus, views, and wizards for the EUDR workflow.
- Translated AI Gateway interfaces and AI summary reporting assets into Italian, ensuring consistent terminology.
- Added Italian strings for supporting modules including lots, oSapiens configuration, surveys, and coffee species reference data.

## Testing
- Not run (translations only)


------
https://chatgpt.com/codex/tasks/task_e_68c9de42da4083338295a159a79ac207

## Summary by Sourcery

Add comprehensive Italian translations across multiple modules

Enhancements:
- Localize Planetio core (models, menus, views, and wizards) into Italian for the EUDR workflow
- Translate AI Gateway interfaces and summary reporting assets into Italian with consistent terminology
- Add Italian translation strings for supporting modules including coffee species reference data, lots, oSapiens configuration, and surveys