### PR TITLE
Add deforestation GeoJSON export attachment

### DIFF
--- a/planetio/models/eudr_deforestation.py
+++ b/planetio/models/eudr_deforestation.py
@@ -287,3 +287,20 @@ class EUDRDeclarationDeforestation(models.Model):
                         pass
                     continue
         return True
+
+    def action_create_deforestation_geojson(self):
+        from ..services.eudr_adapter_odoo import (
+            attach_deforestation_geojson,
+            build_deforestation_geojson,
+        )
+
+        for decl in self:
+            geojson_dict = build_deforestation_geojson(decl)
+            attachment = attach_deforestation_geojson(decl, geojson_dict)
+            decl.message_post(
+                body=_(
+                    "Deforestation GeoJSON created and saved as <b>%s</b>."
+                )
+                % attachment.name
+            )
+        return True

--- a/planetio/views/eudr_views.xml
+++ b/planetio/views/eudr_views.xml
@@ -46,6 +46,8 @@
 <!--                  string="Export GeoJSON" class="oe_highlight" icon="fa-download"/>-->
           <button name="action_analyze_deforestation" type="object" class="oe_highlight btn-success"
                   string="Deforestation analysis" icon="fa-tree"/>
+          <button name="action_create_deforestation_geojson" type="object" class="btn-secondary"
+                  string="Create Deforestation GeoJSON" icon="fa-download"/>
           <button name="action_create_geojson" type="object" class="btn-secondary"
                   string="Create GeoJSON" icon="fa-save"/>
           <button name="action_transmit_dds" type="object" class="oe_highlight"


### PR DESCRIPTION
## Summary
- add a new form button to generate a deforestation analysis GeoJSON attachment
- implement backend helpers to build the deforestation FeatureCollection with analysis results and save it on the record
- refactor GeoJSON attachment handling to reuse a generic helper

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'odoo.tools'; 'odoo' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2dbc46c08333a98222c908772421

## Summary by Sourcery

Add backend and UI support for exporting deforestation analysis as GeoJSON attachments and refactor GeoJSON attachment handling into a generic helper

New Features:
- Introduce build_deforestation_geojson and attach_deforestation_geojson to generate and persist deforestation analysis as GeoJSON on records
- Add an ‘Create Deforestation GeoJSON’ button and action in the form view to trigger the export

Enhancements:
- Refactor GeoJSON attachment creation into a generic _attach_geojson helper and update DDS attachment logic to reuse it
- Add _safe_json_loads, _safe_float, and _get_line_geometry helpers for robust data parsing and geometry extraction
- Ensure JSON dumping uses ensure_ascii=False for proper encoding of GeoJSON attachments