### PR TITLE
Default EUDR net mass when creating declarations

### DIFF
--- a/planetio/models/eudr_models.py
+++ b/planetio/models/eudr_models.py
@@ -384,6 +384,12 @@ class EUDRDeclaration(models.Model):
                 vals['name'] = seq
             if not vals.get('stage_id') and default_stage_id:
                 vals['stage_id'] = default_stage_id
+            # ``net_mass_kg`` is required but certain automated flows (e.g.
+            # GeoJSON imports) create declarations before the weight is known.
+            # Provide a safe default to avoid a validation error and let users
+            # update the value afterwards.
+            if 'net_mass_kg' not in vals:
+                vals['net_mass_kg'] = 0.0
 
         records = super(EUDRDeclaration, self).create(vals_list)
         return records


### PR DESCRIPTION
## Summary
- default the required net_mass_kg field to zero when creating EUDR declarations without a provided weight
- avoid validation errors when automated flows (e.g. GeoJSON imports) create new declarations before the net mass is known

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'odoo.tools'; 'odoo' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68cb341cf11883338efc173bebe7b364

## Summary by Sourcery

Enhancements:
- Provide a fallback default of 0.0 for net_mass_kg when not supplied during declaration creation