### PR TITLE
Fix deforestation analysis stage update and reuse existing declarations for GeoJSON import

### DIFF
--- a/planetio/models/eudr_deforestation.py
+++ b/planetio/models/eudr_deforestation.py
@@ -263,7 +263,9 @@ class EUDRDeclarationLineDeforestation(models.Model):
                 message_type='comment',
                 subtype_xmlid='mail.mt_note',
             )
-        self._set_stage_from_xmlid('planetio.eudr_stage_validated')
+        declarations = lines.mapped('declaration_id')
+        if declarations:
+            declarations._set_stage_from_xmlid('planetio.eudr_stage_validated')
         return True
 
 


### PR DESCRIPTION
## Summary
- update deforestation analysis to set the validation stage on the parent declarations instead of individual lines
- make the GeoJSON import wizard reuse the active declaration from the context, falling back to creating a new one only when necessary
- store the detected declaration on the wizard so subsequent operations keep targeting the same record

## Testing
- python -m compileall planetio

------
https://chatgpt.com/codex/tasks/task_e_68cb3d8aa8cc8333b89c281f860cfb05